### PR TITLE
Change react script srcs from development to production

### DIFF
--- a/eth.html
+++ b/eth.html
@@ -12,8 +12,8 @@
     <meta charset="UTF-8"/>
     <title>corn.lol - crypto trades aggregator</title>
     <meta name="description" content="view large market orders and liquidations for ethereum on bitmex, bitfinex, coinbase and binance.  watch out for arthur!"/>
-    <script src="https://unpkg.com/react@16/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
     <script src="https://unpkg.com/babel-standalone@6.15.0/babel.min.js"></script>
 
     <script src="https://unpkg.com/jquery@3.3.1/dist/jquery.js"></script>

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
     <meta charset="UTF-8"/>
     <title>corn.lol - crypto trades aggregator</title>
     <meta name="description" content="view large market orders and liquidations for bitcoin on bitmex, bitfinex, coinbase and binance.  watch out for arthur!"/>
-    <script src="https://unpkg.com/react@16/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
     <script src="https://unpkg.com/babel-standalone@6.15.0/babel.min.js"></script>
 
     <script src="https://unpkg.com/jquery@3.3.1/dist/jquery.js"></script>


### PR DESCRIPTION
The site is currently using the unminified development links for your react script tags. I changed them to the production ones found here https://reactjs.org/docs/cdn-links.html